### PR TITLE
Enable zend.assertions in composer.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
-          ini-values: zend.assertions=1
           tools: composer:v2
 
       - name: Setup problem matchers for PHP

--- a/composer.json
+++ b/composer.json
@@ -48,8 +48,8 @@
     ],
     "cs-check": "phpcs",
     "cs-fix": "phpcbf",
-    "phpunit": "phpunit --no-coverage",
-    "phpunit-coverage": "phpunit",
+    "phpunit": "@php -dzend.assertions=1 ./vendor/bin/phpunit --no-coverage",
+    "phpunit-coverage": "@php -dzend.assertions=1 ./vendor/bin/phpunit",
     "phpstan": "phpstan analyse",
     "infection": "infection --threads=4 --coverage=build/coverage"
   },


### PR DESCRIPTION
Enables zend.assertions on the fly when running phpunit via composer
script so it must not be enabled in the local php installation for
development.