### PR TITLE
Add option to disable the resolving of dependencies 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,7 @@ trim_trailing_whitespace = false
 
 [*.{yaml, yml, neon, neon.dist, json, json.dist}]
 indent_size = 2
+
+[tests/*/Fixtures/expected/*.json]
+indent_size = 4
+insert_final_newline = false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,10 @@ jobs:
       - name: "Show dependencies"
         run: "composer show"
 
+      - name: "Run code style check"
+        run: "composer run-script cs-check"
+        if: ${{ matrix.composer-deps == 'latest' && matrix.php-version == '7.4' }}
+
       - name: "Run CI"
         run: "composer run-script ci"
 

--- a/bin/openapi-merge
+++ b/bin/openapi-merge
@@ -4,6 +4,7 @@
 use Mthole\OpenApiMerge\Console\Command\MergeCommand;
 use Mthole\OpenApiMerge\Merge\PathMerger;
 use Mthole\OpenApiMerge\OpenApiMerge;
+use Mthole\OpenApiMerge\Merge\ReferenceNormalizer;
 use Mthole\OpenApiMerge\Reader\FileReader;
 use Mthole\OpenApiMerge\Writer\DefinitionWriter;
 use Symfony\Component\Console\Application;
@@ -24,7 +25,11 @@ use Symfony\Component\Console\Application;
 
 $application = new Application();
 $application->add(new MergeCommand(
-    new OpenApiMerge(new FileReader(), new PathMerger()),
+    new OpenApiMerge(
+        new FileReader(),
+        new PathMerger(),
+        new ReferenceNormalizer()
+    ),
     new DefinitionWriter()
 ));
 $application->setDefaultCommand(MergeCommand::COMMAND_NAME, true);

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
   },
   "scripts": {
     "ci": [
-      "@cs-check",
       "@phpunit",
       "@phpstan"
     ],
@@ -46,8 +45,14 @@
       "@phpunit-coverage",
       "@infection"
     ],
-    "cs-check": "phpcs",
-    "cs-fix": "phpcbf",
+    "cs-check": [
+      "phpcs --config-set php_version 70423",
+      "phpcs -s"
+    ],
+    "cs-fix": [
+      "phpcs --config-set php_version 70423",
+      "phpcbf"
+    ],
     "phpunit": "@php -dzend.assertions=1 ./vendor/bin/phpunit --no-coverage",
     "phpunit-coverage": "@php -dxdebug.mode=coverage -dzend.assertions=1 ./vendor/bin/phpunit",
     "phpstan": "phpstan analyse",

--- a/src/Console/Command/MergeCommand.php
+++ b/src/Console/Command/MergeCommand.php
@@ -55,6 +55,13 @@ final class MergeCommand extends Command
             ->addArgument('basefile', InputArgument::REQUIRED)
             ->addArgument('additionalFiles', InputArgument::IS_ARRAY)
             ->addOption(
+                'resolve-references',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Resolve the "$refs" in the given files',
+                true
+            )
+            ->addOption(
                 'outputfile',
                 'o',
                 InputOption::VALUE_OPTIONAL,
@@ -71,12 +78,15 @@ final class MergeCommand extends Command
             throw new Exception('Invalid arguments given');
         }
 
+        $shouldResolveReferences = (bool) $input->getOption('resolve-references');
+
         $mergedResult = $this->merger->mergeFiles(
             new File($baseFile),
-            ...array_map(
+            array_map(
                 static fn (string $file): File => new File($file),
                 $additionalFiles
-            )
+            ),
+            $shouldResolveReferences,
         );
 
         $outputFileName = $input->getOption('outputfile');

--- a/src/Console/Command/MergeCommand.php
+++ b/src/Console/Command/MergeCommand.php
@@ -88,10 +88,10 @@ final class MergeCommand extends Command
                 $mergedResult->getOpenApi()
             );
             file_put_contents(
-                $outputFile->getAbsolutePath(),
+                $outputFile->getAbsoluteFile(),
                 $this->definitionWriter->write($specificationFile)
             );
-            $output->writeln(sprintf('File successfully written to %s', $outputFile->getAbsolutePath()));
+            $output->writeln(sprintf('File successfully written to %s', $outputFile->getAbsoluteFile()));
         } else {
             $output->write($this->definitionWriter->write($mergedResult));
         }

--- a/src/FileHandling/File.php
+++ b/src/FileHandling/File.php
@@ -6,6 +6,7 @@ namespace Mthole\OpenApiMerge\FileHandling;
 
 use Mthole\OpenApiMerge\FileHandling\Exception\IOException;
 
+use function dirname;
 use function getcwd;
 use function pathinfo;
 use function realpath;
@@ -28,7 +29,7 @@ final class File
         return pathinfo($this->filename, PATHINFO_EXTENSION);
     }
 
-    public function getAbsolutePath(): string
+    public function getAbsoluteFile(): string
     {
         $fullFilename = realpath($this->filename);
         if ($fullFilename === false) {
@@ -38,6 +39,11 @@ final class File
         }
 
         return $fullFilename;
+    }
+
+    public function getAbsolutePath(): string
+    {
+        return dirname($this->getAbsoluteFile());
     }
 
     private function createAbsoluteFilePath(string $filename): string

--- a/src/Merge/ReferenceNormalizer.php
+++ b/src/Merge/ReferenceNormalizer.php
@@ -26,6 +26,7 @@ class ReferenceNormalizer
         $refFileCollection = [];
         foreach ($openApiDefinition->paths as $path) {
             foreach ($path->getOperations() as $operation) {
+                assert($operation->responses !== null);
                 foreach ($operation->responses->getResponses() as $statusCode => $response) {
                     if ($response instanceof Reference) {
                         $operation->responses->addResponse(
@@ -54,7 +55,7 @@ class ReferenceNormalizer
                                     $example,
                                     $refFileCollection
                                 );
-                            } else {
+                            } elseif ($example !== null) {
                                 $newExamples[$key] = $example;
                             }
                         }
@@ -78,12 +79,8 @@ class ReferenceNormalizer
     /**
      * @param array<int, string> $refFileCollection
      */
-    private function normalizeReference(?Reference $reference, array &$refFileCollection): ?Reference
+    private function normalizeReference(Reference $reference, array &$refFileCollection): Reference
     {
-        if ($reference === null) {
-            return null;
-        }
-
         $matches       = [];
         $referenceFile = $reference->getReference();
         if (preg_match('~^(?<referenceFile>.*)(?<referenceString>#/.*)~', $referenceFile, $matches) === 1) {

--- a/src/Merge/ReferenceNormalizer.php
+++ b/src/Merge/ReferenceNormalizer.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mthole\OpenApiMerge\Merge;
+
+use cebe\openapi\spec\MediaType;
+use cebe\openapi\spec\OpenApi;
+use cebe\openapi\spec\Reference;
+use cebe\openapi\spec\Response;
+use Mthole\OpenApiMerge\FileHandling\File;
+
+use function array_map;
+use function preg_match;
+
+use const DIRECTORY_SEPARATOR;
+
+class ReferenceNormalizer
+{
+    public function normalizeInlineReferences(
+        File    $openApiFile,
+        OpenApi $openApiDefinition
+    ): ReferenceResolverResult
+    {
+        $refFileCollection = [];
+        foreach ($openApiDefinition->paths as $path) {
+            foreach ($path->getOperations() as $operation) {
+                foreach ($operation->responses->getResponses() as $statusCode => $response) {
+                    if ($response instanceof Reference) {
+                        $operation->responses->addResponse(
+                            $statusCode,
+                            $this->normalizeReference($response, $refFileCollection)
+                        );
+                    }
+                    if (!($response instanceof Response)) {
+                        continue;
+                    }
+
+                    foreach ($response->content as $responseContent) {
+                        /** @var $responseContent MediaType */
+                        if ($responseContent->schema instanceof Reference) {
+                            $responseContent->schema = $this->normalizeReference(
+                                $responseContent->schema,
+                                $refFileCollection
+                            );
+                        }
+                        $newExamples = [];
+                        foreach ($responseContent->examples as $key => $example) {
+                            if ($example instanceof Reference) {
+                                $newExamples[$key] = $this->normalizeReference(
+                                    $example,
+                                    $refFileCollection
+                                );
+                            } else {
+                                $newExamples[$key] = $example;
+                            }
+                        }
+                        if (count($newExamples) > 0) {
+                            $responseContent->examples = $newExamples;
+                        }
+                    }
+                }
+            }
+        }
+
+        return new ReferenceResolverResult(
+            $openApiDefinition,
+            $this->normalizeFilePaths($openApiFile, $refFileCollection)
+        );
+    }
+
+    /**
+     * @param array<int, string> $refFileCollection
+     */
+    private function normalizeReference(?Reference $reference, array &$refFileCollection): ?Reference
+    {
+        if ($reference === null) {
+            return null;
+        }
+
+        $matches       = [];
+        $referenceFile = $reference->getReference();
+        if (preg_match('~^(?<referenceFile>.*)(?<referenceString>#/.*)~', $referenceFile, $matches) === 1) {
+            $refFile = $matches['referenceFile'];
+
+            $refFileCollection[] = $refFile;
+
+            return new Reference(['$ref' => $matches['referenceString']]);
+        }
+
+        return $reference;
+    }
+
+    /**
+     * @param array<int, string> $refFileCollection
+     *
+     * @return array<int, File>
+     */
+    private function normalizeFilePaths(File $openApiFile, array $refFileCollection): array
+    {
+        return array_map(
+            static fn(string $refFile): File => new File(
+                $openApiFile->getAbsolutePath() . DIRECTORY_SEPARATOR . $refFile
+            ),
+            $refFileCollection
+        );
+    }
+}

--- a/src/Merge/ReferenceNormalizer.php
+++ b/src/Merge/ReferenceNormalizer.php
@@ -11,6 +11,8 @@ use cebe\openapi\spec\Response;
 use Mthole\OpenApiMerge\FileHandling\File;
 
 use function array_map;
+use function assert;
+use function count;
 use function preg_match;
 
 use const DIRECTORY_SEPARATOR;
@@ -18,10 +20,9 @@ use const DIRECTORY_SEPARATOR;
 class ReferenceNormalizer
 {
     public function normalizeInlineReferences(
-        File    $openApiFile,
+        File $openApiFile,
         OpenApi $openApiDefinition
-    ): ReferenceResolverResult
-    {
+    ): ReferenceResolverResult {
         $refFileCollection = [];
         foreach ($openApiDefinition->paths as $path) {
             foreach ($path->getOperations() as $operation) {
@@ -32,18 +33,20 @@ class ReferenceNormalizer
                             $this->normalizeReference($response, $refFileCollection)
                         );
                     }
-                    if (!($response instanceof Response)) {
+
+                    if (! ($response instanceof Response)) {
                         continue;
                     }
 
                     foreach ($response->content as $responseContent) {
-                        /** @var $responseContent MediaType */
+                        assert($responseContent instanceof MediaType);
                         if ($responseContent->schema instanceof Reference) {
                             $responseContent->schema = $this->normalizeReference(
                                 $responseContent->schema,
                                 $refFileCollection
                             );
                         }
+
                         $newExamples = [];
                         foreach ($responseContent->examples as $key => $example) {
                             if ($example instanceof Reference) {
@@ -55,9 +58,12 @@ class ReferenceNormalizer
                                 $newExamples[$key] = $example;
                             }
                         }
-                        if (count($newExamples) > 0) {
-                            $responseContent->examples = $newExamples;
+
+                        if (count($newExamples) <= 0) {
+                            continue;
                         }
+
+                        $responseContent->examples = $newExamples;
                     }
                 }
             }
@@ -99,7 +105,7 @@ class ReferenceNormalizer
     private function normalizeFilePaths(File $openApiFile, array $refFileCollection): array
     {
         return array_map(
-            static fn(string $refFile): File => new File(
+            static fn (string $refFile): File => new File(
                 $openApiFile->getAbsolutePath() . DIRECTORY_SEPARATOR . $refFile
             ),
             $refFileCollection

--- a/src/Merge/ReferenceResolverResult.php
+++ b/src/Merge/ReferenceResolverResult.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mthole\OpenApiMerge\Merge;
+
+use cebe\openapi\spec\OpenApi;
+use Mthole\OpenApiMerge\FileHandling\File;
+
+final class ReferenceResolverResult
+{
+    private OpenApi $openApiSpecification;
+    /** @var array<int, File> */
+    private array $foundReferenceFiles;
+
+    /**
+     * @param array<int, File> $foundReferenceFiles
+     */
+    public function __construct(
+        OpenApi $openApiSpecification,
+        array $foundReferenceFiles
+    ) {
+        $this->openApiSpecification = $openApiSpecification;
+        $this->foundReferenceFiles  = $foundReferenceFiles;
+    }
+
+    public function getNormalizedDefinition(): OpenApi
+    {
+        return $this->openApiSpecification;
+    }
+
+    /** @return array<int, File> */
+    public function getFoundReferenceFiles(): array
+    {
+        return $this->foundReferenceFiles;
+    }
+}

--- a/src/OpenApiMerge.php
+++ b/src/OpenApiMerge.php
@@ -7,35 +7,64 @@ namespace Mthole\OpenApiMerge;
 use Mthole\OpenApiMerge\FileHandling\File;
 use Mthole\OpenApiMerge\FileHandling\SpecificationFile;
 use Mthole\OpenApiMerge\Merge\PathMergerInterface;
+use Mthole\OpenApiMerge\Merge\ReferenceNormalizer;
 use Mthole\OpenApiMerge\Reader\FileReader;
+
+use function array_merge;
+use function array_push;
+use function count;
 
 class OpenApiMerge implements OpenApiMergeInterface
 {
     private FileReader $openApiReader;
 
     private PathMergerInterface $pathMerger;
+    private ReferenceNormalizer $referenceNormalizer;
 
     public function __construct(
         FileReader $openApiReader,
-        PathMergerInterface $pathMerger
+        PathMergerInterface $pathMerger,
+        ReferenceNormalizer $referenceResolver
     ) {
-        $this->openApiReader = $openApiReader;
-        $this->pathMerger    = $pathMerger;
+        $this->openApiReader       = $openApiReader;
+        $this->pathMerger          = $pathMerger;
+        $this->referenceNormalizer = $referenceResolver;
     }
 
-    public function mergeFiles(File $baseFile, File ...$additionalFiles): SpecificationFile
+    /** @param array<int, File> $additionalFiles */
+    public function mergeFiles(File $baseFile, array $additionalFiles, bool $resolveReference = true): SpecificationFile
     {
-        $mergedOpenApiDefinition = $this->openApiReader->readFile($baseFile)->getOpenApi();
+        $mergedOpenApiDefinition = $this->openApiReader->readFile($baseFile, $resolveReference)->getOpenApi();
 
-        foreach ($additionalFiles as $additionalFile) {
-            $additionalDefinition           = $this->openApiReader->readFile($additionalFile)->getOpenApi();
+        // use "for" instead of "foreach" to iterate over new added files
+        for ($i = 0; $i < count($additionalFiles); $i++) {
+            $additionalFile       = $additionalFiles[$i];
+            $additionalDefinition = $this->openApiReader->readFile($additionalFile, $resolveReference)->getOpenApi();
+            if (! $resolveReference) {
+                $resolvedReferenceResult = $this->referenceNormalizer->normalizeInlineReferences(
+                    $additionalFile,
+                    $additionalDefinition
+                );
+                array_push($additionalFiles, ...$resolvedReferenceResult->getFoundReferenceFiles());
+                $additionalDefinition = $resolvedReferenceResult->getNormalizedDefinition();
+            }
+
             $mergedOpenApiDefinition->paths = $this->pathMerger->mergePaths(
                 $mergedOpenApiDefinition->paths,
                 $additionalDefinition->paths
             );
+
+            if ($additionalDefinition->components === null) {
+                continue;
+            }
+
+            $mergedOpenApiDefinition->components->schemas = array_merge(
+                $mergedOpenApiDefinition->components->schemas ?? [],
+                $additionalDefinition->components->schemas ?? []
+            );
         }
 
-        if ($mergedOpenApiDefinition->components !== null) {
+        if ($resolveReference && $mergedOpenApiDefinition->components !== null) {
             $mergedOpenApiDefinition->components->schemas = [];
         }
 

--- a/src/OpenApiMerge.php
+++ b/src/OpenApiMerge.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mthole\OpenApiMerge;
 
+use cebe\openapi\spec\Components;
 use Mthole\OpenApiMerge\FileHandling\File;
 use Mthole\OpenApiMerge\FileHandling\SpecificationFile;
 use Mthole\OpenApiMerge\Merge\PathMergerInterface;
@@ -56,6 +57,10 @@ class OpenApiMerge implements OpenApiMergeInterface
 
             if ($additionalDefinition->components === null) {
                 continue;
+            }
+
+            if ($mergedOpenApiDefinition->components === null) {
+                $mergedOpenApiDefinition->components = new Components([]);
             }
 
             $mergedOpenApiDefinition->components->schemas = array_merge(

--- a/src/OpenApiMergeInterface.php
+++ b/src/OpenApiMergeInterface.php
@@ -9,5 +9,10 @@ use Mthole\OpenApiMerge\FileHandling\SpecificationFile;
 
 interface OpenApiMergeInterface
 {
-    public function mergeFiles(File $baseFile, File ...$additionalFiles): SpecificationFile;
+    /** @param array<int, File> $additionalFiles */
+    public function mergeFiles(
+        File $baseFile,
+        array $additionalFiles,
+        bool $resolveReference = true
+    ): SpecificationFile;
 }

--- a/src/Reader/FileReader.php
+++ b/src/Reader/FileReader.php
@@ -17,10 +17,10 @@ final class FileReader
         switch ($inputFile->getFileExtension()) {
             case 'yml':
             case 'yaml':
-                $spec = Reader::readFromYamlFile($inputFile->getAbsolutePath(), OpenApi::class);
+                $spec = Reader::readFromYamlFile($inputFile->getAbsoluteFile(), OpenApi::class);
                 break;
             case 'json':
-                $spec = Reader::readFromJsonFile($inputFile->getAbsolutePath(), OpenApi::class);
+                $spec = Reader::readFromJsonFile($inputFile->getAbsoluteFile(), OpenApi::class);
                 break;
             default:
                 throw InvalidFileTypeException::createFromExtension($inputFile->getFileExtension());

--- a/src/Reader/FileReader.php
+++ b/src/Reader/FileReader.php
@@ -13,7 +13,7 @@ final class FileReader
 {
     private OpenApiReaderWrapper $openApiReader;
 
-    public function __construct(OpenApiReaderWrapper $openApiReader = null)
+    public function __construct(?OpenApiReaderWrapper $openApiReader = null)
     {
         $this->openApiReader = $openApiReader ?? new OpenApiReaderWrapper();
     }
@@ -23,10 +23,18 @@ final class FileReader
         switch ($inputFile->getFileExtension()) {
             case 'yml':
             case 'yaml':
-                $spec = $this->openApiReader->readFromYamlFile($inputFile->getAbsoluteFile(), OpenApi::class, $resolveReferences);
+                $spec = $this->openApiReader->readFromYamlFile(
+                    $inputFile->getAbsoluteFile(),
+                    OpenApi::class,
+                    $resolveReferences
+                );
                 break;
             case 'json':
-                $spec = $this->openApiReader->readFromJsonFile($inputFile->getAbsoluteFile(), OpenApi::class, $resolveReferences);
+                $spec = $this->openApiReader->readFromJsonFile(
+                    $inputFile->getAbsoluteFile(),
+                    OpenApi::class,
+                    $resolveReferences
+                );
                 break;
             default:
                 throw InvalidFileTypeException::createFromExtension($inputFile->getFileExtension());

--- a/src/Reader/FileReader.php
+++ b/src/Reader/FileReader.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mthole\OpenApiMerge\Reader;
 
-use cebe\openapi\Reader;
 use cebe\openapi\spec\OpenApi;
 use Mthole\OpenApiMerge\FileHandling\File;
 use Mthole\OpenApiMerge\FileHandling\SpecificationFile;
@@ -12,15 +11,22 @@ use Mthole\OpenApiMerge\Reader\Exception\InvalidFileTypeException;
 
 final class FileReader
 {
-    public function readFile(File $inputFile): SpecificationFile
+    private OpenApiReaderWrapper $openApiReader;
+
+    public function __construct(OpenApiReaderWrapper $openApiReader = null)
+    {
+        $this->openApiReader = $openApiReader ?? new OpenApiReaderWrapper();
+    }
+
+    public function readFile(File $inputFile, bool $resolveReferences = true): SpecificationFile
     {
         switch ($inputFile->getFileExtension()) {
             case 'yml':
             case 'yaml':
-                $spec = Reader::readFromYamlFile($inputFile->getAbsoluteFile(), OpenApi::class);
+                $spec = $this->openApiReader->readFromYamlFile($inputFile->getAbsoluteFile(), OpenApi::class, $resolveReferences);
                 break;
             case 'json':
-                $spec = Reader::readFromJsonFile($inputFile->getAbsoluteFile(), OpenApi::class);
+                $spec = $this->openApiReader->readFromJsonFile($inputFile->getAbsoluteFile(), OpenApi::class, $resolveReferences);
                 break;
             default:
                 throw InvalidFileTypeException::createFromExtension($inputFile->getFileExtension());

--- a/src/Reader/OpenApiReaderWrapper.php
+++ b/src/Reader/OpenApiReaderWrapper.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Mthole\OpenApiMerge\Reader;
+
+use cebe\openapi\Reader;
+use cebe\openapi\SpecObjectInterface;
+
+class OpenApiReaderWrapper
+{
+    public function readFromYamlFile(string $fileName, string $baseType, bool $resolveReferences): SpecObjectInterface
+    {
+        return Reader::readFromYamlFile($fileName, $baseType, $resolveReferences);
+    }
+
+    public function readFromJsonFile(string $fileName, string $baseType, bool $resolveReferences): SpecObjectInterface
+    {
+        return Reader::readFromJsonFile($fileName, $baseType, $resolveReferences);
+    }
+}

--- a/src/Reader/OpenApiReaderWrapper.php
+++ b/src/Reader/OpenApiReaderWrapper.php
@@ -9,11 +9,25 @@ use cebe\openapi\SpecObjectInterface;
 
 class OpenApiReaderWrapper
 {
+    /**
+     * @phpstan-param class-string<T> $baseType
+     *
+     * @phpstan-return T
+     *
+     * @phpstan-template T of SpecObjectInterface
+     */
     public function readFromYamlFile(string $fileName, string $baseType, bool $resolveReferences): SpecObjectInterface
     {
         return Reader::readFromYamlFile($fileName, $baseType, $resolveReferences);
     }
 
+    /**
+     * @phpstan-param class-string<T> $baseType
+     *
+     * @phpstan-return T
+     *
+     * @phpstan-template T of SpecObjectInterface
+     */
     public function readFromJsonFile(string $fileName, string $baseType, bool $resolveReferences): SpecObjectInterface
     {
         return Reader::readFromJsonFile($fileName, $baseType, $resolveReferences);

--- a/src/Reader/OpenApiReaderWrapper.php
+++ b/src/Reader/OpenApiReaderWrapper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mthole\OpenApiMerge\Reader;
 
 use cebe\openapi\Reader;

--- a/tests/FileHandling/FileTest.php
+++ b/tests/FileHandling/FileTest.php
@@ -14,7 +14,7 @@ use function preg_quote;
 use function str_replace;
 
 /**
- * @uses \Mthole\OpenApiMerge\FileHandling\Exception\IOException
+ * @uses   \Mthole\OpenApiMerge\FileHandling\Exception\IOException
  *
  * @covers \Mthole\OpenApiMerge\FileHandling\File
  */
@@ -40,17 +40,17 @@ class FileTest extends TestCase
         yield ['./../file.dat', 'dat'];
     }
 
-    public function testGetAbsolutePathWithRelativeInvalidFile(): void
+    public function testGetAbsoluteFileWithRelativeInvalidFile(): void
     {
         $sut = new File('dummyfile');
 
         $this->expectException(IOException::class);
         $this->expectExceptionMessageMatches('~\w+/dummyfile"~');
 
-        $sut->getAbsolutePath();
+        $sut->getAbsoluteFile();
     }
 
-    public function testGetAbsolutePathWithAbsoluteInvalidFile(): void
+    public function testGetAbsoluteFileWithAbsoluteInvalidFile(): void
     {
         $invalidFilename = __FILE__ . '-nonexisting.dat';
         $sut             = new File($invalidFilename);
@@ -58,10 +58,10 @@ class FileTest extends TestCase
         $this->expectException(IOException::class);
         $this->expectExceptionMessageMatches('~"' . preg_quote($invalidFilename, '~') . '"~');
 
-        $sut->getAbsolutePath();
+        $sut->getAbsoluteFile();
     }
 
-    public function testGetAbsolutePath(): void
+    public function testGetAbsoluteFile(): void
     {
         $filename = str_replace(
             getcwd() ?: '',
@@ -77,7 +77,13 @@ class FileTest extends TestCase
         $sut = new File($filename);
         self::assertSame(
             __FILE__,
-            $sut->getAbsolutePath()
+            $sut->getAbsoluteFile()
         );
+    }
+
+    public function testGetAbsolutePath(): void
+    {
+        $sut = new File(__FILE__);
+        self::assertSame(__DIR__, $sut->getAbsolutePath());
     }
 }

--- a/tests/Fixtures/routes.yml
+++ b/tests/Fixtures/routes.yml
@@ -15,12 +15,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  response:
-                    type: string
-                required:
-                  - response
+                $ref: '#/components/schemas/pingResponse'
         '400':
           description: Bad Request
           content:
@@ -37,6 +32,16 @@ paths:
           in: query
           name: responseWith
           description: response with this message
+
+components:
+  schemas:
+    pingResponse:
+      type: object
+      properties:
+        response:
+          type: string
+      required:
+        - response
 tags:
   - name: Route
   - name: Base Route

--- a/tests/Merge/Fixtures/expected/openapi-normalized.json
+++ b/tests/Merge/Fixtures/expected/openapi-normalized.json
@@ -1,0 +1,42 @@
+{
+    "openapi": "3.0.0",
+    "info": {},
+    "paths": {
+        "\/dummy": {},
+        "\/reference": {
+            "get": {
+                "responses": {
+                    "100": {
+                        "$ref": "#\/components\/responses\/reference-100"
+                    },
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "text\/html": {
+                                "schema": {}
+                            },
+                            "text\/csv": {
+                                "schema": {},
+                                "examples": {
+                                    "csv-1": {
+                                        "value": "foo,bar"
+                                    }
+                                }
+                            },
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/referenceModel"
+                                },
+                                "examples": {
+                                    "example-1": {
+                                        "$ref": "#\/components\/examples\/referenceModelExample"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Merge/Fixtures/openapi-with-reference.json
+++ b/tests/Merge/Fixtures/openapi-with-reference.json
@@ -1,0 +1,44 @@
+{
+  "openapi": "3.0.0",
+  "info": {},
+  "paths": {
+    "/dummy": {},
+    "/reference": {
+      "get": {
+        "responses": {
+          "100": {
+            "$ref": "./responseModel.json#/components/responses/reference-100"
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/html": {
+                "schema": {
+
+                }
+              },
+              "text/csv": {
+                "schema": {},
+                "examples": {
+                  "csv-1": {
+                    "value": "foo,bar"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "./referenceModel.json#/components/schemas/referenceModel"
+                },
+                "examples": {
+                  "example-1": {
+                    "$ref": "./sub/examples/referenceModel.json#/components/examples/referenceModelExample"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/Merge/Fixtures/referenceModel.json
+++ b/tests/Merge/Fixtures/referenceModel.json
@@ -1,0 +1,24 @@
+{
+  "openapi": "3.0.0",
+  "info": {},
+  "paths": {
+  },
+  "components": {
+    "schemas": {
+      "referenceModel": {
+        "type": "object",
+        "properties": {
+          "isReference": {
+            "type": "boolean"
+          },
+          "references": {
+            "type": "array",
+            "items": {
+              "$ref": "./sub/referenceArrayItem.json#/components/schemas/referenceArrayItem"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/Merge/Fixtures/responseModel.json
+++ b/tests/Merge/Fixtures/responseModel.json
@@ -1,0 +1,13 @@
+{
+  "openapi": "3.0.0",
+  "info": {},
+  "paths": {
+  },
+  "components": {
+    "responses": {
+      "reference-100": {
+        "description": "OK"
+      }
+    }
+  }
+}

--- a/tests/Merge/Fixtures/sub/examples/referenceModel.json
+++ b/tests/Merge/Fixtures/sub/examples/referenceModel.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.0",
+  "info": {},
+  "paths": {
+  },
+  "components": {
+    "examples": {
+      "referenceModelExample": {
+        "value": {
+          "isReference": true,
+          "references": [
+            {"isReferenceInList": true},
+            {"isReferenceInList": false}
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/Merge/Fixtures/sub/referenceArrayItem.json
+++ b/tests/Merge/Fixtures/sub/referenceArrayItem.json
@@ -1,0 +1,18 @@
+{
+  "openapi": "3.0.0",
+  "info": {},
+  "paths": {
+  },
+  "components": {
+    "schemas": {
+      "referenceArrayItem": {
+        "type": "object",
+        "properties": {
+          "isReferenceInList": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/Merge/ReferenceNormalizerTest.php
+++ b/tests/Merge/ReferenceNormalizerTest.php
@@ -23,9 +23,9 @@ class ReferenceNormalizerTest extends TestCase
 {
     public function testReadFileWithResolvedReference(): void
     {
-        $file                          = new File(__DIR__ . '/Fixtures/openapi-with-reference.json');
-        $fileReader                    = new FileReader();
-        $openApi                       = $fileReader->readFile($file, false)->getOpenApi();
+        $file       = new File(__DIR__ . '/Fixtures/openapi-with-reference.json');
+        $fileReader = new FileReader();
+        $openApi    = $fileReader->readFile($file, false)->getOpenApi();
 
         $sut = new ReferenceNormalizer();
 

--- a/tests/Merge/ReferenceNormalizerTest.php
+++ b/tests/Merge/ReferenceNormalizerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mthole\OpenApiMerge\Tests\Merge;
+
+use cebe\openapi\Writer;
+use Mthole\OpenApiMerge\FileHandling\File;
+use Mthole\OpenApiMerge\Merge\ReferenceNormalizer;
+use Mthole\OpenApiMerge\Reader\FileReader;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @uses   \Mthole\OpenApiMerge\Reader\FileReader
+ * @uses   \Mthole\OpenApiMerge\FileHandling\File
+ * @uses   \Mthole\OpenApiMerge\FileHandling\SpecificationFile
+ * @uses   \Mthole\OpenApiMerge\Reader\OpenApiReaderWrapper
+ *
+ * @covers \Mthole\OpenApiMerge\Merge\ReferenceNormalizer
+ * @covers \Mthole\OpenApiMerge\Merge\ReferenceResolverResult
+ */
+class ReferenceNormalizerTest extends TestCase
+{
+    public function testReadFileWithResolvedReference(): void
+    {
+        $file                          = new File(__DIR__ . '/Fixtures/openapi-with-reference.json');
+        $fileReader                    = new FileReader();
+        $openApi                       = $fileReader->readFile($file, false)->getOpenApi();
+
+        $sut = new ReferenceNormalizer();
+
+        $specificationResult = $sut->normalizeInlineReferences(
+            $file,
+            $openApi
+        );
+
+        self::assertStringEqualsFile(
+            __DIR__ . '/Fixtures/expected/openapi-normalized.json',
+            Writer::writeToJson($specificationResult->getNormalizedDefinition())
+        );
+
+        $foundRefFiles = $specificationResult->getFoundReferenceFiles();
+        self::assertCount(3, $foundRefFiles);
+        self::assertSame(
+            __DIR__ . '/Fixtures/responseModel.json',
+            $foundRefFiles[0]->getAbsoluteFile()
+        );
+        self::assertSame(
+            __DIR__ . '/Fixtures/referenceModel.json',
+            $foundRefFiles[1]->getAbsoluteFile()
+        );
+        self::assertSame(
+            __DIR__ . '/Fixtures/sub/examples/referenceModel.json',
+            $foundRefFiles[2]->getAbsoluteFile()
+        );
+    }
+}

--- a/tests/OpenApiMergeTest.php
+++ b/tests/OpenApiMergeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mthole\OpenApiMerge\Tests;
 
+use cebe\openapi\spec\Components;
 use cebe\openapi\spec\OpenApi;
 use Mthole\OpenApiMerge\FileHandling\File;
 use Mthole\OpenApiMerge\Merge\PathMerger;
@@ -101,17 +102,22 @@ class OpenApiMergeTest extends TestCase
             false
         );
 
-        self::assertCount(1, $mergedResult->getOpenApi()->paths);
+        $mergedDefinition = $mergedResult->getOpenApi();
+        if ($mergedDefinition->components === null) {
+            $mergedDefinition->components = new Components([]);
+        }
+
+        self::assertCount(1, $mergedDefinition->paths);
         self::assertSame(
             ['ProblemResponse', 'pingResponse'],
-            array_keys($mergedResult->getOpenApi()->components->schemas)
+            array_keys($mergedDefinition->components->schemas)
         );
     }
 
     public function testReferenceNormalizerWillNotBeExecuted(): void
     {
         $referenceNormalizer = $this->createMock(ReferenceNormalizer::class);
-        $referenceNormalizer->expects(self::never(2))->method('normalizeInlineReferences');
+        $referenceNormalizer->expects(self::never())->method('normalizeInlineReferences');
 
         $sut = new OpenApiMerge(
             new FileReader(),

--- a/tests/OpenApiMergeTest.php
+++ b/tests/OpenApiMergeTest.php
@@ -18,6 +18,7 @@ use function assert;
  * @uses \Mthole\OpenApiMerge\FileHandling\SpecificationFile
  * @uses \Mthole\OpenApiMerge\Reader\FileReader
  * @uses \Mthole\OpenApiMerge\Merge\PathMerger
+ * @uses \Mthole\OpenApiMerge\Reader\OpenApiReaderWrapper
  *
  * @covers \Mthole\OpenApiMerge\OpenApiMerge
  */

--- a/tests/Reader/FileReaderTest.php
+++ b/tests/Reader/FileReaderTest.php
@@ -4,16 +4,19 @@ declare(strict_types=1);
 
 namespace Mthole\OpenApiMerge\Tests\Reader;
 
+use cebe\openapi\spec\OpenApi;
 use Generator;
 use Mthole\OpenApiMerge\FileHandling\File;
 use Mthole\OpenApiMerge\Reader\Exception\InvalidFileTypeException;
 use Mthole\OpenApiMerge\Reader\FileReader;
+use Mthole\OpenApiMerge\Reader\OpenApiReaderWrapper;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @uses \Mthole\OpenApiMerge\FileHandling\File
- * @uses \Mthole\OpenApiMerge\FileHandling\SpecificationFile
- * @uses \Mthole\OpenApiMerge\Reader\Exception\InvalidFileTypeException
+ * @uses   \Mthole\OpenApiMerge\FileHandling\File
+ * @uses   \Mthole\OpenApiMerge\FileHandling\SpecificationFile
+ * @uses   \Mthole\OpenApiMerge\Reader\Exception\InvalidFileTypeException
+ * @uses   \Mthole\OpenApiMerge\Reader\OpenApiReaderWrapper
  *
  * @covers \Mthole\OpenApiMerge\Reader\FileReader
  */
@@ -46,5 +49,33 @@ class FileReaderTest extends TestCase
 
         $this->expectException(InvalidFileTypeException::class);
         $sut->readFile($file);
+    }
+
+    public function testPassResolveReference(): void
+    {
+        $dummyJsonFile = __DIR__ . '/Fixtures/valid-openapi.json';
+        $dummyYamlFile = __DIR__ . '/Fixtures/valid-openapi.yml';
+
+        $readerMock = $this->createMock(OpenApiReaderWrapper::class);
+        $readerMock->expects(self::exactly(3))->method('readFromJsonFile')->withConsecutive(
+            [$dummyJsonFile, OpenApi::class, true],
+            [$dummyJsonFile, OpenApi::class, true],
+            [$dummyJsonFile, OpenApi::class, false],
+        )->willReturn(new OpenApi([]));
+
+        $readerMock->expects(self::exactly(3))->method('readFromYamlFile')->withConsecutive(
+            [$dummyYamlFile, OpenApi::class, true],
+            [$dummyYamlFile, OpenApi::class, true],
+            [$dummyYamlFile, OpenApi::class, false],
+        )->willReturn(new OpenApi([]));
+
+        $sut = new FileReader($readerMock);
+
+        $sut->readFile(new File($dummyJsonFile));
+        $sut->readFile(new File($dummyJsonFile), true);
+        $sut->readFile(new File($dummyJsonFile), false);
+        $sut->readFile(new File($dummyYamlFile));
+        $sut->readFile(new File($dummyYamlFile), true);
+        $sut->readFile(new File($dummyYamlFile), false);
     }
 }

--- a/tests/Reader/FileReaderTest.php
+++ b/tests/Reader/FileReaderTest.php
@@ -44,7 +44,7 @@ class FileReaderTest extends TestCase
         $sut  = new FileReader();
         $file = new File('openapi.neon');
 
-        self::expectException(InvalidFileTypeException::class);
+        $this->expectException(InvalidFileTypeException::class);
         $sut->readFile($file);
     }
 }

--- a/tests/Reader/OpenApiReaderWrapperTest.php
+++ b/tests/Reader/OpenApiReaderWrapperTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Mthole\OpenApiMerge\Tests\Reader;
+
+use cebe\openapi\spec\OpenApi;
+use cebe\openapi\SpecObjectInterface;
+use Mthole\OpenApiMerge\Reader\OpenApiReaderWrapper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Mthole\OpenApiMerge\Reader\OpenApiReaderWrapper
+ */
+class OpenApiReaderWrapperTest extends TestCase
+{
+    public function testCall(): void
+    {
+        $sut = new OpenApiReaderWrapper();
+        self::assertInstanceOf(
+            SpecObjectInterface::class,
+            $sut->readFromJsonFile(
+                __DIR__.'/Fixtures/valid-openapi.json',
+                OpenApi::class,
+                true
+            )
+        );
+        self::assertInstanceOf(
+            SpecObjectInterface::class,
+            $sut->readFromYamlFile(
+                __DIR__.'/Fixtures/valid-openapi.yml',
+                OpenApi::class,
+                true
+            )
+        );
+
+    }
+}

--- a/tests/Reader/OpenApiReaderWrapperTest.php
+++ b/tests/Reader/OpenApiReaderWrapperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mthole\OpenApiMerge\Tests\Reader;
 
 use cebe\openapi\spec\OpenApi;
@@ -18,7 +20,7 @@ class OpenApiReaderWrapperTest extends TestCase
         self::assertInstanceOf(
             SpecObjectInterface::class,
             $sut->readFromJsonFile(
-                __DIR__.'/Fixtures/valid-openapi.json',
+                __DIR__ . '/Fixtures/valid-openapi.json',
                 OpenApi::class,
                 true
             )
@@ -26,11 +28,10 @@ class OpenApiReaderWrapperTest extends TestCase
         self::assertInstanceOf(
             SpecObjectInterface::class,
             $sut->readFromYamlFile(
-                __DIR__.'/Fixtures/valid-openapi.yml',
+                __DIR__ . '/Fixtures/valid-openapi.yml',
                 OpenApi::class,
                 true
             )
         );
-
     }
 }


### PR DESCRIPTION
This adds an option to disable the reference resolving from cebe/openapi and normalize the refs only.
All refs should be remaining in the file and all file paths should be resolving into the local file

resolves #9 