### PR TITLE
allow symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
     "cebe/php-openapi": "^1.7.0",
-    "symfony/console": "^5.1.9 || ^6.0"
+    "symfony/console": "^5.1.9 || ^6.0 || ^7.0"
   },
   "require-dev": {
     "doctrine/coding-standard": "^12.0.0",


### PR DESCRIPTION
There are no real changes in the console package for symfony 7 so nothing to do here. 

The update will not update anything as long as https://github.com/cebe/php-openapi/pull/202 is not merged. 📛 