### PR TITLE
Merge response and request bodies

### DIFF
--- a/src/Merge/ComponentsMerger.php
+++ b/src/Merge/ComponentsMerger.php
@@ -41,6 +41,26 @@ class ComponentsMerger implements MergerInterface
             );
         }
 
+        if (
+            count($existingComponents->requestBodies ?? []) > 0
+            || count($newComponents->requestBodies ?? []) > 0
+        ) {
+            $mergedComponents->requestBodies = array_merge(
+                $existingComponents->requestBodies ?? [],
+                $newComponents->requestBodies ?? [],
+            );
+        }
+
+        if (
+            count($existingComponents->responses ?? []) > 0
+            || count($newComponents->responses ?? []) > 0
+        ) {
+            $mergedComponents->responses = array_merge(
+                $existingComponents->responses ?? [],
+                $newComponents->responses ?? [],
+            );
+        }
+
         $clonedSpec = new OpenApi(Json::toArray($existingSpec->getSerializableData()));
 
         $clonedSpec->components = $mergedComponents;

--- a/src/OpenApiMerge.php
+++ b/src/OpenApiMerge.php
@@ -50,7 +50,9 @@ class OpenApiMerge implements OpenApiMergeInterface
         }
 
         if ($resolveReference && $mergedOpenApiDefinition->components !== null) {
-            $mergedOpenApiDefinition->components->schemas = [];
+            $mergedOpenApiDefinition->components->schemas       = [];
+            $mergedOpenApiDefinition->components->responses     = [];
+            $mergedOpenApiDefinition->components->requestBodies = [];
         }
 
         return new SpecificationFile(

--- a/tests/Acceptance/Fixtures/expected.yml
+++ b/tests/Acceptance/Fixtures/expected.yml
@@ -97,6 +97,8 @@ components:
       type: http
     BasicAuth:
       type: http
+  responses: {  }
+  requestBodies: {  }
 security: []
 tags:
   -

--- a/tests/Acceptance/Fixtures/expected_yaml610.yml
+++ b/tests/Acceptance/Fixtures/expected_yaml610.yml
@@ -97,6 +97,8 @@ components:
       type: http
     BasicAuth:
       type: http
+  responses: {  }
+  requestBodies: {  }
 security: []
 tags:
   -

--- a/tests/Merge/ComponentsMergerTest.php
+++ b/tests/Merge/ComponentsMergerTest.php
@@ -152,5 +152,99 @@ class ComponentsMergerTest extends TestCase
                 ],
             ]),
         ];
+
+        yield 'request bodies first' => [
+            new Components([
+                'requestBodies' => [
+                    'RequestBody' => [],
+                ],
+            ]),
+            null,
+            new Components([
+                'requestBodies' => [
+                    'RequestBody' => [],
+                ],
+            ]),
+        ];
+
+        yield 'request bodies second' => [
+            null,
+            new Components([
+                'requestBodies' => [
+                    'RequestBody' => [],
+                ],
+            ]),
+            new Components([
+                'requestBodies' => [
+                    'RequestBody' => [],
+                ],
+            ]),
+        ];
+
+        yield 'request bodies both' => [
+            new Components([
+                'requestBodies' => [
+                    'RequestBody' => [],
+                ],
+            ]),
+            new Components([
+                'requestBodies' => [
+                    'AnotherRequestBody' => [],
+                ],
+            ]),
+            new Components([
+                'requestBodies' => [
+                    'RequestBody' => [],
+                    'AnotherRequestBody' => [],
+                ],
+            ]),
+        ];
+
+        yield 'responses first' => [
+            new Components([
+                'responses' => [
+                    'ProblemResponse' => [],
+                ],
+            ]),
+            null,
+            new Components([
+                'responses' => [
+                    'ProblemResponse' => [],
+                ],
+            ]),
+        ];
+
+        yield 'responses second' => [
+            null,
+            new Components([
+                'responses' => [
+                    'ProblemResponse' => [],
+                ],
+            ]),
+            new Components([
+                'responses' => [
+                    'ProblemResponse' => [],
+                ],
+            ]),
+        ];
+
+        yield 'responses both' => [
+            new Components([
+                'responses' => [
+                    'ProblemResponse' => [],
+                ],
+            ]),
+            new Components([
+                'responses' => [
+                    'AnotherProblemResponse' => [],
+                ],
+            ]),
+            new Components([
+                'responses' => [
+                    'ProblemResponse' => [],
+                    'AnotherProblemResponse' => [],
+                ],
+            ]),
+        ];
     }
 }


### PR DESCRIPTION
Merges response and requestBodies from components section. 

It is only a top-level merge, so no media-types are merged at this point. I think that would fit most of the cases. 

If at some point we might need a media-type merge it would be easily to implement. 

I did not add any acceptance tests files because as in the acceptance the references are resolved there would be no benefit of using refs in components section. This would only test the underlying OpenApi library. 