### PR TITLE
Remove the return type of the merge Method and modify the existinf spec by reference.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
             composer-deps: latest
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v4"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -44,7 +44,7 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: "Cache dependencies"
-        uses: "actions/cache@v2"
+        uses: "actions/cache@v4"
         with:
           path: "~/.composer/cache"
           key: "php-${{ matrix.php-version }}-composer-${{ matrix.composer-deps }}-${{ hashFiles('**/composer.json') }}"
@@ -80,7 +80,7 @@ jobs:
           - "8.3"
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v4"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -97,7 +97,7 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: "Cache dependencies"
-        uses: "actions/cache@v2"
+        uses: "actions/cache@v4"
         with:
           path: "~/.composer/cache"
           key: "php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}"
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Test Dockerfile
         uses: ./.github/actions/validate-dockerfile

--- a/src/Merge/ComponentsMerger.php
+++ b/src/Merge/ComponentsMerger.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mthole\OpenApiMerge\Merge;
 
-use Mthole\OpenApiMerge\Util\Json;
 use openapiphp\openapi\spec\Components;
 use openapiphp\openapi\spec\OpenApi;
 
@@ -14,11 +13,11 @@ use function count;
 class ComponentsMerger implements MergerInterface
 {
     public function merge(
-        OpenApi $existingSpec,
+        OpenApi $mergedSpec,
         OpenApi $newSpec,
-    ): OpenApi {
+    ): void {
         $mergedComponents   = new Components([]);
-        $existingComponents = $existingSpec->components;
+        $existingComponents = $mergedSpec->components;
         $newComponents      = $newSpec->components;
 
         if (
@@ -71,10 +70,6 @@ class ComponentsMerger implements MergerInterface
             );
         }
 
-        $clonedSpec = new OpenApi(Json::toArray($existingSpec->getSerializableData()));
-
-        $clonedSpec->components = $mergedComponents;
-
-        return $clonedSpec;
+        $mergedSpec->components = $mergedComponents;
     }
 }

--- a/src/Merge/MergerInterface.php
+++ b/src/Merge/MergerInterface.php
@@ -9,7 +9,7 @@ use openapiphp\openapi\spec\OpenApi;
 interface MergerInterface
 {
     public function merge(
-        OpenApi $existingSpec,
+        OpenApi $mergedSpec,
         OpenApi $newSpec,
-    ): OpenApi;
+    ): void;
 }

--- a/src/Merge/PathMerger.php
+++ b/src/Merge/PathMerger.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mthole\OpenApiMerge\Merge;
 
-use Mthole\OpenApiMerge\Util\Json;
 use openapiphp\openapi\spec\OpenApi;
 use openapiphp\openapi\spec\Paths;
 
@@ -22,10 +21,10 @@ class PathMerger implements MergerInterface
     ];
 
     public function merge(
-        OpenApi $existingSpec,
+        OpenApi $mergedSpec,
         OpenApi $newSpec,
-    ): OpenApi {
-        $existingPaths = $existingSpec->paths;
+    ): void {
+        $existingPaths = $mergedSpec->paths;
         $newPaths      = $newSpec->paths;
 
         $pathCopy = new Paths($existingPaths->getPaths());
@@ -50,10 +49,6 @@ class PathMerger implements MergerInterface
             }
         }
 
-        $clonedSpec = new OpenApi(Json::toArray($existingSpec->getSerializableData()));
-
-        $clonedSpec->paths = $pathCopy;
-
-        return $clonedSpec;
+        $mergedSpec->paths = $pathCopy;
     }
 }

--- a/src/Merge/SecurityPathMerger.php
+++ b/src/Merge/SecurityPathMerger.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mthole\OpenApiMerge\Merge;
 
-use Mthole\OpenApiMerge\Util\Json;
 use openapiphp\openapi\spec\OpenApi;
 
 use function count;
@@ -12,14 +11,12 @@ use function count;
 class SecurityPathMerger implements MergerInterface
 {
     public function merge(
-        OpenApi $existingSpec,
+        OpenApi $mergedSpec,
         OpenApi $newSpec,
-    ): OpenApi {
+    ): void {
         if (count($newSpec->security ?? []) === 0) {
-            return $existingSpec;
+            return;
         }
-
-        $clonedSpec = new OpenApi(Json::toArray($existingSpec->getSerializableData()));
 
         foreach ($newSpec->paths->getPaths() as $pathName => $path) {
             foreach ($path->getOperations() as $method => $operation) {
@@ -27,7 +24,7 @@ class SecurityPathMerger implements MergerInterface
                     continue;
                 }
 
-                $path = $clonedSpec->paths->getPath($pathName);
+                $path = $mergedSpec->paths->getPath($pathName);
                 if (! isset($path->{$method}) || $path->{$method} === null) {
                     continue;
                 }
@@ -35,7 +32,5 @@ class SecurityPathMerger implements MergerInterface
                 $path->{$method}->security = $newSpec->security;
             }
         }
-
-        return $clonedSpec;
     }
 }

--- a/src/OpenApiMerge.php
+++ b/src/OpenApiMerge.php
@@ -60,7 +60,7 @@ class OpenApiMerge implements OpenApiMergeInterface
             }
 
             foreach ($this->merger as $merger) {
-                $mergedOpenApiDefinition = $merger->merge(
+                $merger->merge(
                     $mergedOpenApiDefinition,
                     $additionalDefinition,
                 );

--- a/tests/Merge/ComponentsMergerTest.php
+++ b/tests/Merge/ComponentsMergerTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
+use function count;
+use function get_object_vars;
+
 #[CoversClass(ComponentsMerger::class)]
 #[UsesClass(Json::class)]
 class ComponentsMergerTest extends TestCase
@@ -28,9 +31,12 @@ class ComponentsMergerTest extends TestCase
         $newSpec      = new OpenApi(['components' => $newComponents]);
         $expectedSpec = new OpenApi(['components' => $expectedComponents]);
 
-        $stateBefore = $existingSpec->getSerializableData();
-        self::assertEquals($expectedSpec, $sut->merge($existingSpec, $newSpec));
-        self::assertEquals($stateBefore, $existingSpec->getSerializableData());
+        if ($newComponents !== null && count(get_object_vars($newComponents->getSerializableData())) > 0) {
+            self::assertNotEquals($expectedSpec, $existingSpec);
+        }
+
+        $sut->merge($existingSpec, $newSpec);
+        self::assertEquals($expectedSpec, $existingSpec);
     }
 
     /** @return iterable<string, list<Components|null>> */

--- a/tests/Merge/PathMergerTest.php
+++ b/tests/Merge/PathMergerTest.php
@@ -30,11 +30,11 @@ class PathMergerTest extends TestCase
         $existingSpec = new OpenApi(['paths' => $existingPath]);
         $newSpec      = new OpenApi(['paths' => $newPaths]);
 
-        $sut     = new PathMerger();
-        $newSpec = $sut->merge($existingSpec, $newSpec);
+        $sut = new PathMerger();
+        $sut->merge($existingSpec, $newSpec);
         self::assertCount(1, $existingPath);
         self::assertCount(1, $newPaths);
-        self::assertCount(2, $newSpec->paths);
+        self::assertCount(2, $existingSpec->paths);
     }
 
     /**
@@ -50,16 +50,17 @@ class PathMergerTest extends TestCase
         array $expectedRoutes,
         array $expectedMethods,
     ): void {
-        $sut         = new PathMerger();
-        $mergedPaths = $sut->merge(
-            new OpenApi(['paths' => $existingPaths]),
+        $sut          = new PathMerger();
+        $existingSpec = new OpenApi(['paths' => $existingPaths]);
+        $sut->merge(
+            $existingSpec,
             new OpenApi(['paths' => $newPaths]),
         );
 
-        self::assertSame($expectedRoutes, array_keys($mergedPaths->paths->getPaths()));
+        self::assertSame($expectedRoutes, array_keys($existingSpec->paths->getPaths()));
 
         foreach ($expectedMethods as $routeName => $expectedRouteMethods) {
-            $pathItem = $mergedPaths->paths->getPath($routeName);
+            $pathItem = $existingSpec->paths->getPath($routeName);
             self::assertNotNull($pathItem);
             self::assertSame(
                 $expectedRouteMethods,

--- a/tests/Merge/SecurityPathMergerTest.php
+++ b/tests/Merge/SecurityPathMergerTest.php
@@ -24,13 +24,13 @@ class SecurityPathMergerTest extends TestCase
     ): void {
         $sut = new SecurityPathMerger();
 
-        $result = $sut->merge(
+        $sut->merge(
             $existingSpec,
             $newSpec,
         );
 
         $stateBefore = $existingSpec->getSerializableData();
-        self::assertEquals($expectedSpec, $result);
+        self::assertEquals($expectedSpec, $existingSpec);
         self::assertEquals($stateBefore, $existingSpec->getSerializableData());
     }
 


### PR DESCRIPTION
This will reduce the time for loading over 1500 Spec files from 2 minutes to 1 second.

new - fixtures contains 1500 files
```
/var/www # time php bin/openapi-merge fixtures/api.openapi.json --resolve-references=0 -- $(find fixtures/ -type f -iname '*.openapi.json' | xargs) > /dev/null
real    0m 0.86s
user    0m 0.67s
sys     0m 0.18s
``` 

old - fixtures contains 1500 files
```
/var/www # time php bin/openapi-merge fixtures/api.openapi.json --resolve-references=0 -- $(find fixtures/ -type f -iname '*.openapi.json' | xargs) > /dev/null
real    2m 2.03s
user    2m 0.82s
sys     0m 1.16s
````
